### PR TITLE
Raytracing performance improvements

### DIFF
--- a/data/shader/ao/rtao.csh
+++ b/data/shader/ao/rtao.csh
@@ -71,7 +71,7 @@ void main() {
         float curSeed = float(0);
 
         ivec2 noiseOffset = Unflatten2D(int(frameSeed), ivec2(16)) * ivec2(8);
-        vec2 blueNoiseVec = texelFetch(randomTexture, ((pixel % ivec2(8)) + noiseOffset) % ivec2(128), 0).xy * 256.0;
+        vec2 blueNoiseVec = texelFetch(randomTexture, (pixel + noiseOffset) % ivec2(128), 0).xy * 256.0;
 		blueNoiseVec = clamp(blueNoiseVec, 0.0, 255.0);
 		blueNoiseVec = (blueNoiseVec + 0.5) / 256.0;
 

--- a/data/shader/brdf/brdfEval.hsh
+++ b/data/shader/brdf/brdfEval.hsh
@@ -4,7 +4,7 @@
 #include <../common/PI.hsh>
 #include <../common/utility.hsh>
 
-layout(binding = 9) uniform sampler2D dfgTexture;
+layout(binding = 31) uniform sampler2D dfgTexture;
 
 vec3 EvaluateDiffuseBRDF(Surface surface) {
 

--- a/data/shader/ddgi/rayHit.csh
+++ b/data/shader/ddgi/rayHit.csh
@@ -73,7 +73,7 @@ vec3 EvaluateHit(inout Ray ray) {
 	// Unpack the compressed triangle and extract surface parameters
 	Triangle tri = UnpackTriangle(triangles[ray.hitID]);
 	bool backfaceHit;	
-	Surface surface = GetSurfaceParameters(tri, ray, false, backfaceHit);
+	Surface surface = GetSurfaceParameters(tri, ray, false, backfaceHit, 4);
 
 	// Indicates backface hit
 	if (backfaceHit) {

--- a/data/shader/pathtracer/rayHit.csh
+++ b/data/shader/pathtracer/rayHit.csh
@@ -98,7 +98,7 @@ void EvaluateBounce(inout Ray ray, inout RayPayload payload) {
 	
 	// Unpack the compressed triangle and extract surface parameters
 	Triangle tri = UnpackTriangle(triangles[ray.hitID]);
-	Surface surface = GetSurfaceParameters(tri, ray, true);
+	Surface surface = GetSurfaceParameters(tri, ray, true, 0);
 
 	// If we hit an emissive surface we need to terminate the ray
 	if (dot(surface.material.emissiveColor, vec3(1.0)) > 0.0 &&

--- a/data/shader/raytracer/bvh.hsh
+++ b/data/shader/raytracer/bvh.hsh
@@ -141,7 +141,7 @@ float CheckLeafTransparency(inout Ray ray, int nodePtr, float tmin, float tmax, 
 		if (intersect && sol.x > tmin && sol.x < tmax && d <= 0.0) {
 			ray.hitDistance = sol.x;
 			ray.hitID = triPtr;
-			transparency *= (1.0 - GetOpacity(tri, sol.yz, 1));
+			transparency *= (1.0 - GetOpacity(tri, sol.yz, 0));
 		}
 		triPtr++;
 	}

--- a/data/shader/raytracer/bvh.hsh
+++ b/data/shader/raytracer/bvh.hsh
@@ -141,7 +141,7 @@ float CheckLeafTransparency(inout Ray ray, int nodePtr, float tmin, float tmax, 
 		if (intersect && sol.x > tmin && sol.x < tmax && d <= 0.0) {
 			ray.hitDistance = sol.x;
 			ray.hitID = triPtr;
-			transparency *= (1.0 - GetOpacity(tri, sol.yz));
+			transparency *= (1.0 - GetOpacity(tri, sol.yz, 1));
 		}
 		triPtr++;
 	}

--- a/data/shader/raytracer/structures.hsh
+++ b/data/shader/raytracer/structures.hsh
@@ -70,8 +70,7 @@ struct Triangle {
 	
 };
 
-struct Texture {
-	
+struct TextureLevel  {
 	int layer;
 	
 	int x;
@@ -79,7 +78,18 @@ struct Texture {
 	
 	int width;
 	int height;
+
+	int valid;
+};
+
+struct Texture {
+	TextureLevel level0;
+	TextureLevel level1;
+	TextureLevel level2;
+	TextureLevel level3;
+	TextureLevel level4;
 	
+	int valid;
 };
 
 struct RaytraceMaterial {

--- a/data/shader/raytracer/surface.hsh
+++ b/data/shader/raytracer/surface.hsh
@@ -27,7 +27,7 @@ Material GetTriangleMaterial(Triangle tri, out RaytraceMaterial rayMat) {
 	return mat;
 }
 
-Surface GetSurfaceParameters(Triangle tri, Ray ray, bool useNormalMaps, out bool backfaceHit) {
+Surface GetSurfaceParameters(Triangle tri, Ray ray, bool useNormalMaps, out bool backfaceHit, int textureLevel) {
 
 	Surface surface;
 	RaytraceMaterial rayMat;
@@ -60,21 +60,22 @@ Surface GetSurfaceParameters(Triangle tri, Ray ray, bool useNormalMaps, out bool
 	triangleNormal *= flipNormal ? -1.0 : 1.0;
 
 	vec3 geometryNormal = normal;
-		
-	mat.baseColor *= SampleBaseColorBilinear(rayMat.baseColorTexture, texCoord);
-	mat.opacity *= SampleOpacityBilinear(rayMat.opacityTexture, texCoord);
 	
-	mat.roughness *= SampleRoughnessBilinear(rayMat.roughnessTexture, texCoord);
-	mat.metalness *= SampleMetalnessBilinear(rayMat.metalnessTexture, texCoord);
-	mat.ao *= SampleAoBilinear(rayMat.aoTexture, texCoord);
+	int level = textureLevel;
+	mat.baseColor *= SampleBaseColorBilinear(GetTextureLevel(rayMat.baseColorTexture, level), texCoord);
+	mat.opacity *= SampleOpacityBilinear(GetTextureLevel(rayMat.opacityTexture, level), texCoord);
+	
+	mat.roughness *= SampleRoughnessBilinear(GetTextureLevel(rayMat.roughnessTexture, level), texCoord);
+	mat.metalness *= SampleMetalnessBilinear(GetTextureLevel(rayMat.metalnessTexture, level), texCoord);
+	mat.ao *= SampleAoBilinear(GetTextureLevel(rayMat.aoTexture, level), texCoord);
 	
 	// Account for changing texture coord direction
 	vec3 bitangent = rayMat.invertUVs > 0 ? tri.bt : -tri.bt;
 	mat3 TBN = mat3(tri.t, bitangent, normal);
 	
 	// Sample normal map
-	if (rayMat.normalTexture.layer >= 0 && useNormalMaps) {
-		vec3 texNormal = 2.0 * SampleNormalBilinear(rayMat.normalTexture, texCoord) - 1.0;
+	if (rayMat.normalTexture.valid >= 0 && useNormalMaps) {
+		vec3 texNormal = 2.0 * SampleNormalBilinear(GetTextureLevel(rayMat.normalTexture, level), texCoord) - 1.0;
 		texNormal = TBN * texNormal;
 		// Make sure we don't divide by zero
 		// The normalize function crashes the program in case of vec3(0.0)
@@ -99,12 +100,12 @@ Surface GetSurfaceParameters(Triangle tri, Ray ray, bool useNormalMaps, out bool
 
 }
 
-Surface GetSurfaceParameters(Triangle tri, Ray ray, bool useNormalMaps) {
+Surface GetSurfaceParameters(Triangle tri, Ray ray, bool useNormalMaps, int textureLevel) {
 	bool normalFlipped;
-	return GetSurfaceParameters(tri, ray, useNormalMaps, normalFlipped);
+	return GetSurfaceParameters(tri, ray, useNormalMaps, normalFlipped, textureLevel);
 }
 
-float GetOpacity(Triangle tri, vec2 barrycentric) {
+float GetOpacity(Triangle tri, vec2 barrycentric, int textureLevel) {
 	float s = barrycentric.x;
 	float t = barrycentric.y;
 	float r = 1.0 - s - t;
@@ -114,5 +115,5 @@ float GetOpacity(Triangle tri, vec2 barrycentric) {
 	vec2 texCoord = r * tri.uv0 + s * tri.uv1 + t * tri.uv2;		
 	texCoord = rayMat.invertUVs > 0 ? vec2(texCoord.x, 1.0 - texCoord.y) : texCoord;
 
-	return rayMat.opacity * SampleOpacityBilinear(rayMat.opacityTexture, texCoord);
+	return rayMat.opacity * SampleOpacityBilinear(GetTextureLevel(rayMat.opacityTexture, textureLevel), texCoord);
 }

--- a/data/shader/raytracer/texture.hsh
+++ b/data/shader/raytracer/texture.hsh
@@ -9,107 +9,116 @@ layout (binding = 4) uniform sampler2DArray metalnessTextures;
 layout (binding = 5) uniform sampler2DArray aoTextures;
 layout (binding = 6) uniform samplerCube environmentMap;
 
-vec2 GetTexCoord(vec2 texCoord, Texture tex, vec2 size) {
+vec2 GetTexCoord(vec2 texCoord, TextureLevel level, vec2 size) {
 	
-	return (vec2(mod(texCoord.x, float(tex.width) - 0.5),
-		mod(texCoord.y, float(tex.height) - 0.5)) + 
-		vec2(tex.x, tex.y)) / size;
+	return (vec2(mod(texCoord.x, float(level.width) - 0.5),
+		mod(texCoord.y, float(level.height) - 0.5)) + 
+		vec2(level.x, level.y)) / size;
 		
 }
 
-vec3 SampleBaseColorBilinear(Texture tex, vec2 texCoord) {
+TextureLevel GetTextureLevel(Texture texture, int level) {
+	if (level == 0) return texture.level0;
+	else if (level == 1) return texture.level1;
+	else if (level == 2) return texture.level2;
+	else if (level == 3) return texture.level3;
+	else if (level == 4) return texture.level4;
+	else return texture.level4;
+}
+
+vec3 SampleBaseColorBilinear(TextureLevel level, vec2 texCoord) {
 	
-	if (tex.layer < 0)
+	if (level.valid < 0)
 		return vec3(1.0);
 		
-	texCoord *= vec2(tex.width - 1, tex.height - 1);
+	texCoord *= vec2(level.width - 1, level.height - 1);
 	texCoord += vec2(0.5);
 	
 	vec2 size = vec2(textureSize(baseColorTextures, 0));
-	texCoord = GetTexCoord(texCoord, tex, size);
+	texCoord = GetTexCoord(texCoord, level, size);
 	
 	return textureLod(baseColorTextures, 
-		vec3(texCoord, float(tex.layer)), 0).rgb;
+		vec3(texCoord, float(level.layer)), 0).rgb;
 	
 }
 
-float SampleOpacityBilinear(Texture tex, vec2 texCoord) {
+float SampleOpacityBilinear(TextureLevel level, vec2 texCoord) {
 	
-	if (tex.layer < 0)
+	if (level.valid < 0)
 		return 1.0;
 		
-	texCoord *= vec2(tex.width - 1, tex.height - 1);
+	texCoord *= vec2(level.width - 1, level.height - 1);
 	texCoord += vec2(0.5);
 	
 	vec2 size = vec2(textureSize(opacityTextures, 0));
-	texCoord = GetTexCoord(texCoord, tex, size);
+	texCoord = GetTexCoord(texCoord, level, size);
 	
 	return textureLod(opacityTextures, 
-		vec3(texCoord, float(tex.layer)), 0).r;
+		vec3(texCoord, float(level.layer)), 0).r;
 	
 }
 
-vec3 SampleNormalBilinear(Texture tex, vec2 texCoord) {
+vec3 SampleNormalBilinear(TextureLevel level, vec2 texCoord) {
 	
-	if (tex.layer < 0)
+	if (level.valid < 0)
 		return vec3(1.0);
 		
-	texCoord *= vec2(tex.width - 1, tex.height - 1);
+	texCoord *= vec2(level.width - 1, level.height - 1);
 	texCoord += vec2(0.5);
 	
 	vec2 size = vec2(textureSize(normalTextures, 0));
-	texCoord = GetTexCoord(texCoord, tex, size);
+	texCoord = GetTexCoord(texCoord, level, size);
 	
 	return textureLod(normalTextures, 
-		vec3(texCoord, float(tex.layer)), 0).rgb;
+		vec3(texCoord, float(level.layer)), 0).rgb;
 	
 }
 
-float SampleRoughnessBilinear(Texture tex, vec2 texCoord) {
+float SampleRoughnessBilinear(TextureLevel level, vec2 texCoord) {
 	
-	if (tex.layer < 0)
+	if (level.valid < 0)
 		return 1.0;
 		
-	texCoord *= vec2(tex.width - 1, tex.height - 1);
+	texCoord *= vec2(level.width - 1, level.height - 1);
 	texCoord += vec2(0.5);
 	
 	vec2 size = vec2(textureSize(roughnessTextures, 0));
-	texCoord = GetTexCoord(texCoord, tex, size);
+	texCoord = GetTexCoord(texCoord, level, size);
 	
 	return textureLod(roughnessTextures, 
-		vec3(texCoord, float(tex.layer)), 0).r;
+		vec3(texCoord, float(level.layer)), 0).r;
 	
 }
 
-float SampleMetalnessBilinear(Texture tex, vec2 texCoord) {
+float SampleMetalnessBilinear(TextureLevel level, vec2 texCoord) {
 	
-	if (tex.layer < 0)
+	if (level.valid < 0)
 		return 1.0;
 		
-	texCoord *= vec2(tex.width - 1, tex.height - 1);
+	texCoord *= vec2(level.width - 1, level.height - 1);
 	texCoord += vec2(0.5);
 	
 	vec2 size = vec2(textureSize(metalnessTextures, 0));
-	texCoord = GetTexCoord(texCoord, tex, size);
+	texCoord = GetTexCoord(texCoord, level, size);
 	
 	return textureLod(metalnessTextures, 
-		vec3(texCoord, float(tex.layer)), 0).r;
+		vec3(texCoord, float(level.layer)), 0).r;
 	
 }
 
-float SampleAoBilinear(Texture tex, vec2 texCoord) {
+float SampleAoBilinear(TextureLevel level, vec2 texCoord) {
 	
-	if (tex.layer < 0)
+	if (level.valid < 0)
 		return 1.0;
 		
-	texCoord *= vec2(tex.width - 1, tex.height - 1);
+	texCoord *= vec2(level.width - 1, level.height - 1);
 	texCoord += vec2(0.5);
 	
 	vec2 size = vec2(textureSize(aoTextures, 0));
-	texCoord = GetTexCoord(texCoord, tex, size);
+	texCoord = GetTexCoord(texCoord, level, size);
 	
 	return textureLod(aoTextures, 
-		vec3(texCoord, float(tex.layer)), 0).r;
+		vec3(texCoord, float(level.layer)), 0).r;
 	
 }
 

--- a/data/shader/reflection/rtreflection.csh
+++ b/data/shader/reflection/rtreflection.csh
@@ -155,7 +155,7 @@ vec3 EvaluateHit(inout Ray ray) {
 	// Unpack the compressed triangle and extract surface parameters
 	Triangle tri = UnpackTriangle(triangles[ray.hitID]);
 	bool backfaceHit;	
-	Surface surface = GetSurfaceParameters(tri, ray, false, backfaceHit);
+	Surface surface = GetSurfaceParameters(tri, ray, false, backfaceHit, 4);
 	
 	radiance += surface.material.emissiveColor;
 

--- a/data/shader/reflection/rtreflection.csh
+++ b/data/shader/reflection/rtreflection.csh
@@ -95,17 +95,23 @@ void main() {
                 Ray ray;
 
 				float alpha = sqr(material.roughness);
-				float biasedAlpha = (1.0 - bias) * alpha;
 
 				vec3 V = normalize(-viewVec);
 				vec3 N = worldNorm;
 
-                float pdf;
-                ImportanceSampleGGX(blueNoiseVec, N, V, biasedAlpha,
-                                    ray.direction, pdf);
+				blueNoiseVec.y *= (1.0 - bias);
 
-                if (pdf <= 0.0) {
-					// What should we do here?
+				if (material.roughness > 0.02) {
+					float pdf;
+					ImportanceSampleGGX(blueNoiseVec, N, V, alpha,
+										ray.direction, pdf);
+				}
+				else {
+					ray.direction = normalize(reflect(-V, N));
+				}
+
+                if (dot(N, ray.direction) < 0.0) {
+					//reflection += vec3(100.0, 0.0, 0.0);
                     continue;
                 }
 
@@ -128,8 +134,8 @@ void main() {
 #endif
 				}
 
-				float radianceMax = max(max(radiance.r, 
-						max(radiance.g, radiance.b)), radianceLimit);
+				float radianceMax = max(max(max(radiance.r, 
+						max(radiance.g, radiance.b)), radianceLimit), 0.01);
 				reflection += radiance * (radianceLimit / radianceMax);
             }
 

--- a/demo/App.cpp
+++ b/demo/App.cpp
@@ -373,6 +373,7 @@ void App::Render(float deltaTime) {
 				// ImGui::SliderInt("Sample count", &reflection->sampleCount, 1, 32);
 				ImGui::SliderFloat("Radiance Limit##Reflection", &reflection->radianceLimit, 0.0f, 10.0f);
 				ImGui::SliderFloat("Bias##Reflection", &reflection->bias, 0.0f, 1.0f);
+				ImGui::SliderFloat("Spatial filter strength##Reflection", &reflection->spatialFilterStrength, 0.0f, 10.0f);
 			}
 			if (ImGui::CollapsingHeader("Camera")) {
 				ImGui::SliderFloat("Exposure##Camera", &camera.exposure, 0.0f, 10.0f);

--- a/demo/App.cpp
+++ b/demo/App.cpp
@@ -143,7 +143,7 @@ void App::Render(float deltaTime) {
 
 		viewport.Set(0, 0, window.GetWidth(), window.GetHeight());
 		masterRenderer.RenderTexture(&viewport, &pathTraceTarget.texture, 0.0f, 0.0f,
-			(float)viewport.width, (float)viewport.height);
+			float(viewport.width), float(viewport.height));
 	}
 	else {
 		viewport.Set(0, 0, window.GetWidth(), window.GetHeight());
@@ -151,11 +151,11 @@ void App::Render(float deltaTime) {
 
 		if (debugAo) {
 			masterRenderer.RenderTexture(&viewport, &renderTarget->aoTexture, 0.0f, 0.0f,
-				viewport.width, viewport.height, false, true);
+				float(viewport.width), float(viewport.height), false, true);
 		}
 		if (debugReflection) {
 			masterRenderer.RenderTexture(&viewport, &renderTarget->reflectionTexture, 0.0f, 0.0f,
-				viewport.width, viewport.height, false, true);
+				float(viewport.width), float(viewport.height), false, true);
 		}
 	}
 	

--- a/demo/App.cpp
+++ b/demo/App.cpp
@@ -363,7 +363,7 @@ void App::Render(float deltaTime) {
 			if (ImGui::CollapsingHeader("Reflection (preview)")) {
 				ImGui::Checkbox("Debug##Reflection", &debugReflection);
 				ImGui::Checkbox("Enable reflection", &reflection->enable);
-				ImGui::Checkbox("Enable raytracing##Reflection", &reflection->rt);
+				//ImGui::Checkbox("Enable raytracing##Reflection", &reflection->rt);
 				ImGui::Checkbox("Use shadow map", &reflection->useShadowMap);
 				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
 					ImGui::SetTooltip("Uses the shadow map to calculate shadows in reflections. \

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -2,8 +2,6 @@
 
 namespace Atlas {
 
-	uint32_t Framebuffer::boundFramebufferID = 0;
-
 	Framebuffer::Framebuffer() {
 
 		glGenFramebuffers(1, &ID);
@@ -187,22 +185,25 @@ namespace Atlas {
 
 	void Framebuffer::Bind(bool resizeViewport) {
 
-		if (boundFramebufferID != ID) {
-
-			if (resizeViewport) {
-				glViewport(0, 0, width, height);
-			}
-
-			glBindFramebuffer(GL_FRAMEBUFFER, ID);
-
-			boundFramebufferID = ID;
+		if (resizeViewport) {
+			glViewport(0, 0, width, height);
 		}
+
+		glBindFramebuffer(GL_FRAMEBUFFER, ID);
+	}
+
+	void Framebuffer::Bind(int32_t target, bool resizeViewport) {
+
+		if (resizeViewport) {
+			glViewport(0, 0, width, height);
+		}
+
+		glBindFramebuffer(target, ID);
 	}
 
 	void Framebuffer::Unbind() {
 
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		boundFramebufferID = 0;
 
 	}
 

--- a/src/Framebuffer.h
+++ b/src/Framebuffer.h
@@ -120,6 +120,12 @@ namespace Atlas {
 		void Bind(bool resizeViewport = false);
 
 		/**
+		 *
+		 * @param resizeViewport
+		 */
+		void Bind(int32_t target, bool resizeViewport = false);
+
+		/**
 		 * Unbinds any framebuffer.
 		 */
 		void Unbind();
@@ -156,8 +162,6 @@ namespace Atlas {
 
 		std::unordered_map<int32_t, Component> components;
 		std::vector<uint32_t> drawBuffers;
-
-		static uint32_t boundFramebufferID;
 
 	};
 

--- a/src/lighting/Reflection.h
+++ b/src/lighting/Reflection.h
@@ -18,7 +18,8 @@ namespace Atlas {
 
 			int32_t sampleCount = 1;
 			float radianceLimit = 2.0f;
-			float bias = 0.0f;
+			float bias = 0.15f;
+			float spatialFilterStrength = 5.0f;
 
 			bool enable = true;
 			bool rt = false;

--- a/src/renderer/AORenderer.cpp
+++ b/src/renderer/AORenderer.cpp
@@ -62,6 +62,7 @@ namespace Atlas {
             auto materialIdxTexture = downsampledRT->materialIdxTexture;
             auto randomTexture = &scene->ao->noiseTexture;
 
+            auto historyDepthTexture = downsampledHistoryRT->depthTexture;
             auto historyMaterialIdxTexture = downsampledHistoryRT->materialIdxTexture;
             auto historyNormalTexture = downsampledHistoryRT->geometryNormalTexture;
 
@@ -121,7 +122,7 @@ namespace Atlas {
 
                 ao->noiseTexture.Bind(GL_TEXTURE3);
 
-                target->swapAoTexture.Bind(GL_WRITE_ONLY, 0);
+                target->aoTexture.Bind(GL_WRITE_ONLY, 0);
 
                 glDispatchCompute(groupCount.x, groupCount.y, 1);
             }
@@ -138,13 +139,18 @@ namespace Atlas {
                 target->aoTexture.Bind(GL_WRITE_ONLY, 0);
                 target->aoMomentsTexture.Bind(GL_WRITE_ONLY, 1);
 
-                target->historyAoTexture.Bind(GL_TEXTURE0);
-                target->swapAoTexture.Bind(GL_TEXTURE1);
-                velocityTexture->Bind(GL_TEXTURE2);
-                depthTexture->Bind(GL_TEXTURE3);
-                normalTexture->Bind(GL_TEXTURE6);
-                materialIdxTexture->Bind(GL_TEXTURE7);
-                target->historyAoMomentsTexture.Bind(GL_TEXTURE10);
+                target->swapAoTexture.Bind(GL_TEXTURE0);
+                velocityTexture->Bind(GL_TEXTURE1);
+                depthTexture->Bind(GL_TEXTURE2);
+                roughnessTexture->Bind(GL_TEXTURE3);
+                normalTexture->Bind(GL_TEXTURE4);
+                materialIdxTexture->Bind(GL_TEXTURE5);
+
+                target->historyAoTexture.Bind(GL_TEXTURE6);
+                target->historyAoMomentsTexture.Bind(GL_TEXTURE7);
+                historyDepthTexture->Bind(GL_TEXTURE8);
+                historyNormalTexture->Bind(GL_TEXTURE9);
+                historyMaterialIdxTexture->Bind(GL_TEXTURE10);
 
                 temporalShader.GetUniform("ipMatrix")->SetValue(camera->invProjectionMatrix);
                 temporalShader.GetUniform("invResolution")->SetValue(1.0f / vec2((float)res.x, (float)res.y));

--- a/src/renderer/DirectionalLightRenderer.cpp
+++ b/src/renderer/DirectionalLightRenderer.cpp
@@ -22,7 +22,7 @@ namespace Atlas {
 		}
 
 		void DirectionalLightRenderer::Render(Viewport* viewport, RenderTarget* target,
-				Camera* camera, Scene::Scene* scene, Texture::Texture2D* dfgTexture) {
+				Camera* camera, Scene::Scene* scene) {
 
 			Profiler::BeginQuery("Directional lights");
 
@@ -41,7 +41,6 @@ namespace Atlas {
 			target->geometryFramebuffer.GetComponentTexture(GL_COLOR_ATTACHMENT3)->Bind(GL_TEXTURE3);
 			target->geometryFramebuffer.GetComponentTexture(GL_COLOR_ATTACHMENT4)->Bind(GL_TEXTURE4);
 			target->geometryFramebuffer.GetComponentTexture(GL_DEPTH_ATTACHMENT)->Bind(GL_TEXTURE5);
-			dfgTexture->Bind(GL_TEXTURE9);
 
 			if (scene->sky.probe) {
 				scene->sky.probe->cubemap.Bind(GL_TEXTURE10);

--- a/src/renderer/DirectionalLightRenderer.h
+++ b/src/renderer/DirectionalLightRenderer.h
@@ -13,11 +13,8 @@ namespace Atlas {
         public:
             DirectionalLightRenderer();
 
-            void Render(Viewport* viewport, RenderTarget* target, Camera* camera,
-                Scene::Scene* scene) final {}
-
             void Render(Viewport* viewport, RenderTarget* target, Camera* camera, 
-                Scene::Scene* scene, Texture::Texture2D* dfgTexture);
+                Scene::Scene* scene);
 
         private:
             void GetUniforms();

--- a/src/renderer/MasterRenderer.cpp
+++ b/src/renderer/MasterRenderer.cpp
@@ -81,6 +81,8 @@ namespace Atlas {
 
 			PrepareMaterials(scene, materials, materialMap);
 
+			dfgPreintegrationTexture.Bind(GL_TEXTURE31);
+
 			auto materialBuffer = Buffer::Buffer(AE_SHADER_STORAGE_BUFFER, sizeof(PackedMaterial), 0,
 				materials.size(), materials.data());
 
@@ -187,10 +189,10 @@ namespace Atlas {
 
 			glDisable(GL_BLEND);
 
-			vertexArray.Bind();
-
 			aoRenderer.Render(viewport, target, camera, scene);
 			rtrRenderer.Render(viewport, target, camera, scene);
+
+			vertexArray.Bind();
 
 			target->lightingFramebuffer.Bind(true);
 			target->lightingFramebuffer.SetDrawBuffers({ GL_COLOR_ATTACHMENT0 });
@@ -198,7 +200,7 @@ namespace Atlas {
 			glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 			glClear(GL_COLOR_BUFFER_BIT);
 
-			directionalLightRenderer.Render(viewport, target, camera, scene, &dfgPreintegrationTexture);
+			directionalLightRenderer.Render(viewport, target, camera, scene);
 
 			indirectLightRenderer.Render(viewport, target, camera, scene);
 
@@ -635,7 +637,7 @@ namespace Atlas {
 				glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 				glClear(GL_COLOR_BUFFER_BIT);
 
-				directionalLightRenderer.Render(&viewport, target, &camera, scene, &dfgPreintegrationTexture);
+				directionalLightRenderer.Render(&viewport, target, &camera, scene);
 
 				glEnable(GL_DEPTH_TEST);
 

--- a/src/renderer/RTReflectionRenderer.cpp
+++ b/src/renderer/RTReflectionRenderer.cpp
@@ -23,8 +23,17 @@ namespace Atlas {
             temporalShader.AddStage(AE_COMPUTE_STAGE, "reflection/temporal.csh");
             temporalShader.Compile();
 
-            atrousShader.AddStage(AE_COMPUTE_STAGE, "reflection/atrous.csh");
-            atrousShader.Compile();
+            atrousShader[0].AddStage(AE_COMPUTE_STAGE, "reflection/atrous.csh");
+            atrousShader[0].AddMacro("STEP_SIZE1");
+            atrousShader[0].Compile();
+
+            atrousShader[1].AddStage(AE_COMPUTE_STAGE, "reflection/atrous.csh");
+            atrousShader[1].AddMacro("STEP_SIZE2");
+            atrousShader[1].Compile();
+
+            atrousShader[2].AddStage(AE_COMPUTE_STAGE, "reflection/atrous.csh");
+            atrousShader[2].AddMacro("STEP_SIZE4");
+            atrousShader[2].Compile();
 
 		}
 
@@ -62,6 +71,7 @@ namespace Atlas {
             auto materialIdxTexture = downsampledRT->materialIdxTexture;
             auto randomTexture = &scene->ao->noiseTexture;
 
+            auto historyDepthTexture = downsampledHistoryRT->depthTexture;
             auto historyMaterialIdxTexture = downsampledHistoryRT->materialIdxTexture;
             auto historyNormalTexture = downsampledHistoryRT->geometryNormalTexture;
 
@@ -163,17 +173,18 @@ namespace Atlas {
                 target->reflectionTexture.Bind(GL_WRITE_ONLY, 0);
                 target->reflectionMomentsTexture.Bind(GL_WRITE_ONLY, 1);
 
-                target->historyReflectionTexture.Bind(GL_TEXTURE0);
-                target->swapReflectionTexture.Bind(GL_TEXTURE1);
-                velocityTexture->Bind(GL_TEXTURE2);
-                depthTexture->Bind(GL_TEXTURE3);
-                roughnessTexture->Bind(GL_TEXTURE4);
-                offsetTexture->Bind(GL_TEXTURE5);
-                normalTexture->Bind(GL_TEXTURE6);
-                materialIdxTexture->Bind(GL_TEXTURE7);
-                historyMaterialIdxTexture->Bind(GL_TEXTURE8);
+                target->swapReflectionTexture.Bind(GL_TEXTURE0);
+                velocityTexture->Bind(GL_TEXTURE1);
+                depthTexture->Bind(GL_TEXTURE2);
+                roughnessTexture->Bind(GL_TEXTURE3);
+                normalTexture->Bind(GL_TEXTURE4);
+                materialIdxTexture->Bind(GL_TEXTURE5);
+
+                target->historyReflectionTexture.Bind(GL_TEXTURE6);
+                target->historyReflectionMomentsTexture.Bind(GL_TEXTURE7);
+                historyDepthTexture->Bind(GL_TEXTURE8);
                 historyNormalTexture->Bind(GL_TEXTURE9);
-                target->historyReflectionMomentsTexture.Bind(GL_TEXTURE10);
+                historyMaterialIdxTexture->Bind(GL_TEXTURE10);
 
                 temporalShader.GetUniform("ipMatrix")->SetValue(camera->invProjectionMatrix);
                 temporalShader.GetUniform("invResolution")->SetValue(1.0f / vec2((float)res.x, (float)res.y));
@@ -189,11 +200,11 @@ namespace Atlas {
             Profiler::EndAndBeginQuery("Spatial filter");
 
             {
-                ivec2 groupCount = ivec2(res.x / 8, res.y / 8);
-                groupCount.x += ((groupCount.x * 8 == res.x) ? 0 : 1);
-                groupCount.y += ((groupCount.y * 8 == res.y) ? 0 : 1);
+                ivec2 groupCount = ivec2(res.x / 16, res.y / 16);
+                groupCount.x += ((groupCount.x * 16 == res.x) ? 0 : 1);
+                groupCount.y += ((groupCount.y * 16 == res.y) ? 0 : 1);
 
-                atrousShader.Bind();
+                
 
                 bool pingpong = true;
 
@@ -201,11 +212,16 @@ namespace Atlas {
                 normalTexture->Bind(GL_TEXTURE2);
                 roughnessTexture->Bind(GL_TEXTURE3);
 
-                atrousShader.GetUniform("ipMatrix")->SetValue(camera->invProjectionMatrix);
-
-                for (int32_t i = 0; i < 4; i++) {
+                for (int32_t i = 0; i < 3; i++) {
                     Profiler::BeginQuery("Subpass " + std::to_string(i));
-                    atrousShader.GetUniform("stepSize")->SetValue(1 << i);
+
+                    atrousShader[i].Bind();
+
+                    atrousShader[i].GetUniform("ipMatrix")->SetValue(camera->invProjectionMatrix);
+                    atrousShader[i].GetUniform("resolution")->SetValue(res);
+                    atrousShader[i].GetUniform("strength")->SetValue(reflection->spatialFilterStrength);
+
+                    atrousShader[i].GetUniform("stepSize")->SetValue(1 << i);
 
                     if (pingpong) {
                         target->reflectionTexture.Bind(GL_TEXTURE0);
@@ -222,7 +238,12 @@ namespace Atlas {
                     glDispatchCompute(groupCount.x, groupCount.y, 1);
                     Profiler::EndQuery();
                 }
-            }            
+
+                if (!pingpong) {
+                    glMemoryBarrier(GL_ALL_BARRIER_BITS);
+                    target->reflectionTexture = target->swapReflectionTexture;
+                }
+            }
 
             Profiler::EndQuery();
             Profiler::EndQuery();

--- a/src/renderer/RTReflectionRenderer.cpp
+++ b/src/renderer/RTReflectionRenderer.cpp
@@ -154,9 +154,9 @@ namespace Atlas {
             Profiler::EndAndBeginQuery("Temporal filter");
 
             {
-                ivec2 groupCount = ivec2(res.x / 8, res.y / 8);
-                groupCount.x += ((groupCount.x * 8 == res.x) ? 0 : 1);
-                groupCount.y += ((groupCount.y * 8 == res.y) ? 0 : 1);
+                ivec2 groupCount = ivec2(res.x / 16, res.y / 16);
+                groupCount.x += ((groupCount.x * 16 == res.x) ? 0 : 1);
+                groupCount.y += ((groupCount.y * 16 == res.y) ? 0 : 1);
 
                 temporalShader.Bind();
 

--- a/src/renderer/RTReflectionRenderer.h
+++ b/src/renderer/RTReflectionRenderer.h
@@ -26,8 +26,8 @@ namespace Atlas {
 
 			Shader::Shader rtrShader;
 			Shader::Shader temporalShader;
-			Shader::Shader atrousShader;
 
+			Shader::Shader atrousShader[3];
 		};
 
 	}

--- a/src/renderer/helper/RayTracingHelper.cpp
+++ b/src/renderer/helper/RayTracingHelper.cpp
@@ -132,17 +132,17 @@ namespace Atlas {
 					Texture::Texture::Unbind(GL_TEXTURE_CUBE_MAP, GL_TEXTURE6);
 
 					if (rtData.baseColorTextureAtlas.slices.size())
-						rtData.baseColorTextureAtlas.texture.Bind(GL_TEXTURE0);
+						rtData.baseColorTextureAtlas.textureArray.Bind(GL_TEXTURE0);
 					if (rtData.opacityTextureAtlas.slices.size())
-						rtData.opacityTextureAtlas.texture.Bind(GL_TEXTURE1);
+						rtData.opacityTextureAtlas.textureArray.Bind(GL_TEXTURE1);
 					if (rtData.normalTextureAtlas.slices.size())
-						rtData.normalTextureAtlas.texture.Bind(GL_TEXTURE2);
+						rtData.normalTextureAtlas.textureArray.Bind(GL_TEXTURE2);
 					if (rtData.roughnessTextureAtlas.slices.size())
-						rtData.roughnessTextureAtlas.texture.Bind(GL_TEXTURE3);
+						rtData.roughnessTextureAtlas.textureArray.Bind(GL_TEXTURE3);
 					if (rtData.metalnessTextureAtlas.slices.size())
-						rtData.metalnessTextureAtlas.texture.Bind(GL_TEXTURE4);
+						rtData.metalnessTextureAtlas.textureArray.Bind(GL_TEXTURE4);
 					if (rtData.aoTextureAtlas.slices.size())
-						rtData.aoTextureAtlas.texture.Bind(GL_TEXTURE5);
+						rtData.aoTextureAtlas.textureArray.Bind(GL_TEXTURE5);
 					if (scene->sky.probe)
 						scene->sky.probe->cubemap.Bind(GL_TEXTURE6);
 
@@ -249,17 +249,17 @@ namespace Atlas {
 					Texture::Texture::Unbind(GL_TEXTURE_CUBE_MAP, GL_TEXTURE6);
 
 					if (rtData.baseColorTextureAtlas.slices.size())
-						rtData.baseColorTextureAtlas.texture.Bind(GL_TEXTURE0);
+						rtData.baseColorTextureAtlas.textureArray.Bind(GL_TEXTURE0);
 					if (rtData.opacityTextureAtlas.slices.size())
-						rtData.opacityTextureAtlas.texture.Bind(GL_TEXTURE1);
+						rtData.opacityTextureAtlas.textureArray.Bind(GL_TEXTURE1);
 					if (rtData.normalTextureAtlas.slices.size())
-						rtData.normalTextureAtlas.texture.Bind(GL_TEXTURE2);
+						rtData.normalTextureAtlas.textureArray.Bind(GL_TEXTURE2);
 					if (rtData.roughnessTextureAtlas.slices.size())
-						rtData.roughnessTextureAtlas.texture.Bind(GL_TEXTURE3);
+						rtData.roughnessTextureAtlas.textureArray.Bind(GL_TEXTURE3);
 					if (rtData.metalnessTextureAtlas.slices.size())
-						rtData.metalnessTextureAtlas.texture.Bind(GL_TEXTURE4);
+						rtData.metalnessTextureAtlas.textureArray.Bind(GL_TEXTURE4);
 					if (rtData.aoTextureAtlas.slices.size())
-						rtData.aoTextureAtlas.texture.Bind(GL_TEXTURE5);
+						rtData.aoTextureAtlas.textureArray.Bind(GL_TEXTURE5);
 					if (scene->sky.probe)
 						scene->sky.probe->cubemap.Bind(GL_TEXTURE6);
 

--- a/src/scene/RTData.cpp
+++ b/src/scene/RTData.cpp
@@ -382,93 +382,39 @@ namespace Atlas {
 						gpuMaterial.twoSided = material.twoSided ? 1 : 0;
 
 						if (material.HasBaseColorMap()) {
-							auto slice = baseColorTextureAtlas.slices[material.baseColorMap];
+							auto& slices = baseColorTextureAtlas.slices[material.baseColorMap];
 
-							gpuMaterial.baseColorTexture.layer = slice.layer;
-
-							gpuMaterial.baseColorTexture.x = slice.offset.x;
-							gpuMaterial.baseColorTexture.y = slice.offset.y;
-
-							gpuMaterial.baseColorTexture.width = slice.size.x;
-							gpuMaterial.baseColorTexture.height = slice.size.y;
-						}
-						else {
-							gpuMaterial.baseColorTexture.layer = -1;
+							gpuMaterial.baseColorTexture = CreateGPUTextureStruct(slices);
 						}
 
 						if (material.HasOpacityMap()) {
-							auto slice = opacityTextureAtlas.slices[material.opacityMap];
+							auto& slices = opacityTextureAtlas.slices[material.opacityMap];
 
-							gpuMaterial.opacityTexture.layer = slice.layer;
-
-							gpuMaterial.opacityTexture.x = slice.offset.x;
-							gpuMaterial.opacityTexture.y = slice.offset.y;
-
-							gpuMaterial.opacityTexture.width = slice.size.x;
-							gpuMaterial.opacityTexture.height = slice.size.y;
-						}
-						else {
-							gpuMaterial.opacityTexture.layer = -1;
+							gpuMaterial.opacityTexture = CreateGPUTextureStruct(slices);
 						}
 
 						if (material.HasNormalMap()) {
-							auto slice = normalTextureAtlas.slices[material.normalMap];
+							auto& slices = normalTextureAtlas.slices[material.normalMap];
 
-							gpuMaterial.normalTexture.layer = slice.layer;
-
-							gpuMaterial.normalTexture.x = slice.offset.x;
-							gpuMaterial.normalTexture.y = slice.offset.y;
-
-							gpuMaterial.normalTexture.width = slice.size.x;
-							gpuMaterial.normalTexture.height = slice.size.y;
-						}
-						else {
-							gpuMaterial.normalTexture.layer = -1;
+							gpuMaterial.normalTexture = CreateGPUTextureStruct(slices);
 						}
 
 						if (material.HasRoughnessMap()) {
-							auto slice = roughnessTextureAtlas.slices[material.roughnessMap];
+							auto& slices = roughnessTextureAtlas.slices[material.roughnessMap];
 
-							gpuMaterial.roughnessTexture.layer = slice.layer;
-
-							gpuMaterial.roughnessTexture.x = slice.offset.x;
-							gpuMaterial.roughnessTexture.y = slice.offset.y;
-
-							gpuMaterial.roughnessTexture.width = slice.size.x;
-							gpuMaterial.roughnessTexture.height = slice.size.y;
-						}
-						else {
-							gpuMaterial.roughnessTexture.layer = -1;
+							gpuMaterial.roughnessTexture = CreateGPUTextureStruct(slices);
 						}
 
 						if (material.HasMetalnessMap()) {
-							auto slice = metalnessTextureAtlas.slices[material.metalnessMap];
+							auto& slices = metalnessTextureAtlas.slices[material.metalnessMap];
 
-							gpuMaterial.metalnessTexture.layer = slice.layer;
-
-							gpuMaterial.metalnessTexture.x = slice.offset.x;
-							gpuMaterial.metalnessTexture.y = slice.offset.y;
-
-							gpuMaterial.metalnessTexture.width = slice.size.x;
-							gpuMaterial.metalnessTexture.height = slice.size.y;
-						}
-						else {
-							gpuMaterial.metalnessTexture.layer = -1;
+							gpuMaterial.metalnessTexture = CreateGPUTextureStruct(slices);
 						}
 
 						if (material.HasAoMap()) {
-							auto slice = aoTextureAtlas.slices[material.aoMap];
+							auto& slices = aoTextureAtlas.slices[material.aoMap];
 
-							gpuMaterial.aoTexture.layer = slice.layer;
-
-							gpuMaterial.aoTexture.x = slice.offset.x;
-							gpuMaterial.aoTexture.y = slice.offset.y;
-
-							gpuMaterial.aoTexture.width = slice.size.x;
-							gpuMaterial.aoTexture.height = slice.size.y;
-						}
-						else {
-							gpuMaterial.aoTexture.layer = -1;
+							gpuMaterial.aoTexture = CreateGPUTextureStruct(slices);
 						}
 
 						materials.push_back(gpuMaterial);
@@ -525,6 +471,39 @@ namespace Atlas {
 			roughnessTextureAtlas = Texture::TextureAtlas(roughnessTextures, 1, textureDownscale);
 			metalnessTextureAtlas = Texture::TextureAtlas(metalnessTextures, 1, textureDownscale);
 			aoTextureAtlas = Texture::TextureAtlas(aoTextures, 1, textureDownscale);
+
+		}
+
+		RTData::GPUTexture RTData::CreateGPUTextureStruct(std::vector<Texture::TextureAtlas::Slice> slices) {
+
+			GPUTexture texture;
+
+			if (slices.size() > 0) texture.level0 = CreateGPUTextureLevelStruct(slices[0]);
+			if (slices.size() > 1) texture.level1 = CreateGPUTextureLevelStruct(slices[1]);
+			if (slices.size() > 2) texture.level2 = CreateGPUTextureLevelStruct(slices[2]);
+			if (slices.size() > 3) texture.level3 = CreateGPUTextureLevelStruct(slices[3]);
+			if (slices.size() > 4) texture.level4 = CreateGPUTextureLevelStruct(slices[4]);
+
+			texture.valid = 1;
+
+			return texture;
+
+		}
+
+		RTData::GPUTextureLevel RTData::CreateGPUTextureLevelStruct(Texture::TextureAtlas::Slice slice) {
+
+			GPUTextureLevel level;
+
+			level.x = slice.offset.x;
+			level.y = slice.offset.y;
+
+			level.width = slice.size.x;
+			level.height = slice.size.y;
+
+			level.layer = slice.layer;
+			level.valid = 1;
+
+			return level;
 
 		}
 

--- a/src/scene/RTData.h
+++ b/src/scene/RTData.h
@@ -49,8 +49,7 @@ namespace Atlas {
 				vec4 v2;
 			};
 
-			struct GPUTexture {
-
+			struct GPUTextureLevel {
 				int32_t layer;
 
 				int32_t x;
@@ -59,6 +58,17 @@ namespace Atlas {
 				int32_t width;
 				int32_t height;
 
+				int32_t valid = -1;
+			};
+
+			struct GPUTexture {
+				GPUTextureLevel level0;
+				GPUTextureLevel level1;
+				GPUTextureLevel level2;
+				GPUTextureLevel level3;
+				GPUTextureLevel level4;
+
+				int32_t valid = -1;
 			};
 
 			struct GPUMaterial {
@@ -109,6 +119,10 @@ namespace Atlas {
 
 			std::unordered_map<Material*, int32_t> UpdateMaterials(std::vector<GPUMaterial>& materials,
 				bool updateTextures);
+
+			GPUTexture CreateGPUTextureStruct(std::vector<Texture::TextureAtlas::Slice> slices);
+
+			GPUTextureLevel CreateGPUTextureLevelStruct(Texture::TextureAtlas::Slice slice);
 
 			Scene* scene;
 

--- a/src/scene/RTData.h
+++ b/src/scene/RTData.h
@@ -50,13 +50,13 @@ namespace Atlas {
 			};
 
 			struct GPUTextureLevel {
-				int32_t layer;
+				int32_t layer = 0;
 
-				int32_t x;
-				int32_t y;
+				int32_t x = 0;
+				int32_t y = 0;
 
-				int32_t width;
-				int32_t height;
+				int32_t width = 0;
+				int32_t height = 0;
 
 				int32_t valid = -1;
 			};

--- a/src/texture/TextureAtlas.cpp
+++ b/src/texture/TextureAtlas.cpp
@@ -30,7 +30,7 @@ namespace Atlas {
 				slices = that.slices;
 				padding = that.padding;
 
-				texture = that.texture;
+				textureArray = that.textureArray;
 
 			}
 
@@ -105,7 +105,7 @@ namespace Atlas {
 			default: sizedFormat = AE_RGBA8; break;
 			}
 
-			texture = Texture2DArray(width, height, layers, sizedFormat, GL_CLAMP_TO_EDGE, GL_LINEAR);
+			textureArray = Texture2DArray(width, height, layers, sizedFormat, GL_CLAMP_TO_EDGE, GL_LINEAR);
 
 			// Copy all levels to the texture array (note that the order levels are added is important)
 			for (auto& levelSlices : levels) {
@@ -227,7 +227,7 @@ namespace Atlas {
 				if (tex->channels == channels) {
 
 					readFramebuffer.AddComponentTexture(GL_COLOR_ATTACHMENT0, tex);
-					writeFramebuffer.AddComponentTextureArray(GL_COLOR_ATTACHMENT0, &texture, slice.layer);
+					writeFramebuffer.AddComponentTextureArray(GL_COLOR_ATTACHMENT0, &textureArray, slice.layer);
 
 					readFramebuffer.Bind(GL_READ_FRAMEBUFFER);
 					writeFramebuffer.Bind(GL_DRAW_FRAMEBUFFER);
@@ -282,7 +282,7 @@ namespace Atlas {
 						convertedData = image.GetData();
 					}
 
-					texture.SetData(convertedData, slice.offset.x,
+					textureArray.SetData(convertedData, slice.offset.x,
 						slice.offset.y, slice.layer, slice.size.x,
 						slice.size.y, 1);
 

--- a/src/texture/TextureAtlas.cpp
+++ b/src/texture/TextureAtlas.cpp
@@ -1,6 +1,8 @@
 #include "TextureAtlas.h"
 
 #include "../shader/ShaderManager.h"
+#include "../Framebuffer.h"
+#include "../Log.h"
 
 #include <algorithm>
 
@@ -39,17 +41,7 @@ namespace Atlas {
 		void TextureAtlas::Update(std::vector<Texture2D*>& textures) {
 
 			if (!textures.size())
-				return;
-
-			// Use structure to allow for downscaling without
-			// invalidating the original textures and without
-			// needing to copy them
-			struct TextureStructure {
-				int32_t width;
-				int32_t height;
-				int32_t channels;
-				Texture2D* texture;
-			};
+				return;			
 
 			std::vector<TextureStructure> textureStructures;
 
@@ -63,9 +55,6 @@ namespace Atlas {
 					}
 				);
 			};
-
-			int32_t width = 0, height = 0, 
-				layers = 0, channels = 0;
 
 			for (auto& texture : textureStructures) {
 				width = texture.width > width ?
@@ -91,78 +80,20 @@ namespace Atlas {
 
 			// Approximation of total padding by assuming to stuff
 			// the smallest texture over and over again.
-			auto& smallest = textureStructures[textureStructures.size() - 1];
+			auto& smallest = textureStructures.back();
 			auto smallestSize = glm::max(ivec2(smallest.width, smallest.height), glm::ivec2(1));
 			ivec2 totalPadding = ivec2(width, height) / smallestSize * padding;
 
 			// Add total padding to total size
 			width += totalPadding.x;
 			height += totalPadding.y;
+			
+			std::vector<std::map<Texture2D*, TextureAtlas::Slice>> levels;
 
-			while(textureStructures.size()) {
-
-				auto textureStruct = textureStructures[0];
-				auto texture = textureStruct.texture;
-				textureStructures.erase(textureStructures.begin());
-
-				slices[texture].layer = layers;
-				slices[texture].offset = ivec2(0);
-				slices[texture].size = ivec2(textureStruct.width, textureStruct.height);
-
-				ivec2 size = ivec2(textureStruct.width, textureStruct.height);
-				ivec2 offset = ivec2(size.x + padding, 0);
-
-				if ((size.x == width && size.y == height) ||
-					!textureStructures.size()) {
-					layers++;
-					continue;
-				}
-
-				size_t outerTex = 0;
-				while (outerTex != textureStructures.size()) {
-					outerTex = textureStructures.size();
-
-					if (!textureStructures.size())
-						break;
-
-					size_t innerTex = 0;
-					while (innerTex != textureStructures.size()) {
-						innerTex = textureStructures.size();
-
-						if (!textureStructures.size() || offset.x == width)
-							break;
-
-						for (size_t i = 0; i < textureStructures.size(); i++) {
-
-							textureStruct = textureStructures[i];
-							texture = textureStruct.texture;
-
-							ivec2 remain = ivec2(width, height) - offset;
-							ivec2 texSize = ivec2(textureStruct.width, textureStruct.height);
-
-							if (remain.x - texSize.x >= 0 &&
-								remain.y - texSize.y >= 0 &&
-								texSize.x <= size.x &&
-								texSize.y <= size.y) {
-								slices[texture].layer = layers;
-								slices[texture].offset = offset;
-								slices[texture].size = texSize;
-								offset.x += texSize.x + padding;
-								textureStructures.erase(textureStructures.begin() + i);
-								break;
-							}
-
-						}
-
-					}
-
-					offset.y += size.y + padding;
-					offset.x = 0;
-
-				}
-
-				layers++;
-
+			// This will create slices for four texture levels, each downsampled by a factor of two
+			for (int32_t i = 0; i < 5; i++) {
+				const auto levelSlices = CreateSlicesForAtlasLevel(textureStructures, i);
+				levels.push_back(levelSlices);
 			}
 
 			int32_t sizedFormat;
@@ -176,22 +107,145 @@ namespace Atlas {
 
 			texture = Texture2DArray(width, height, layers, sizedFormat, GL_CLAMP_TO_EDGE, GL_LINEAR);
 
-			for (auto& key : slices) {
+			// Copy all levels to the texture array (note that the order levels are added is important)
+			for (auto& levelSlices : levels) {
+				FillAtlas(levelSlices);
+			}
+
+		}
+
+		std::map<Texture2D*, TextureAtlas::Slice> TextureAtlas::CreateSlicesForAtlasLevel(std::vector<TextureStructure> textures, int32_t level) {
+
+			std::map<Texture2D*, TextureAtlas::Slice> levelSlices;
+
+			int32_t downsampleFactor = pow(2, level);
+
+			for (auto& texture : textures) {
+				texture.width /= downsampleFactor;
+				texture.height /= downsampleFactor;
+
+				texture.width = glm::max(texture.width, 1);
+				texture.height = glm::max(texture.height, 1);
+			}
+
+			// Reuse the offset for levels larger than zero
+			// This reduces the layer by not creating a new one for each level
+			bool reuseOffset = level != 0;
+			// Try to add data to a lower layer for levels > 0
+			if (reuseOffset) layers--;
+
+			while (textures.size()) {
+
+				offset = reuseOffset ? offset : ivec2(0);
+				// Only reuse offset at first loop iteration
+				reuseOffset = false;				
+
+				size_t outerTex = 0;
+				while (outerTex != textures.size()) {
+					outerTex = textures.size();
+
+					// Break here, we don't want to increment the y-offset twice when no data is left
+					if (!textures.size())
+						break;
+
+					// Attempt to place the front most texture into the new roe
+					auto textureStruct = textures.front();
+					auto texture = textureStruct.texture;
+
+					ivec2 size = ivec2(textureStruct.width, textureStruct.height);
+					ivec2 remain = ivec2(width, height) - offset;
+
+					// We need to increase the layer in case no space is left
+					if (remain.x - size.x < 0 ||
+						remain.y - size.y < 0) {
+						break;
+					}
+
+					levelSlices[texture].layer = layers;
+					levelSlices[texture].offset = offset;
+					levelSlices[texture].size = size;
+
+					textures.erase(textures.begin());
+
+					offset.x += size.x + padding;
+
+					size_t innerTex = 0;
+					while (innerTex != textures.size()) {
+						innerTex = textures.size();
+
+						if (!textures.size() || offset.x == width)
+							break;
+
+						// Try to find a texture which might still fit in the
+						// the current row
+						for (size_t i = 0; i < textures.size(); i++) {
+
+							textureStruct = textures[i];
+							texture = textureStruct.texture;
+
+							remain = ivec2(width, height) - offset;
+							ivec2 texSize = ivec2(textureStruct.width, textureStruct.height);
+
+							if (remain.x - texSize.x >= 0 &&
+								remain.y - texSize.y >= 0 &&
+								texSize.x <= size.x &&
+								texSize.y <= size.y) {
+								levelSlices[texture].layer = layers;
+								levelSlices[texture].offset = offset;
+								levelSlices[texture].size = texSize;
+								offset.x += texSize.x + padding;
+								textures.erase(textures.begin() + i);
+								break;
+							}
+
+						}
+
+					}
+
+					offset.y += size.y + padding;
+					offset.x = 0;
+
+				}
+
+				layers++;				
+
+			}
+
+			return levelSlices;
+
+		}
+
+		void TextureAtlas::FillAtlas(std::map<Texture2D*, TextureAtlas::Slice> levelSlices) {
+
+			Framebuffer readFramebuffer;
+			Framebuffer writeFramebuffer;
+
+			for (auto& key : levelSlices) {
 				auto tex = key.first;
 				auto slice = key.second;
 
-				auto data = tex->GetData<uint8_t>();
-
-				std::vector<uint8_t> convertedData;
-
 				if (tex->channels == channels) {
 
-					convertedData = data;
+					readFramebuffer.AddComponentTexture(GL_COLOR_ATTACHMENT0, tex);
+					writeFramebuffer.AddComponentTextureArray(GL_COLOR_ATTACHMENT0, &texture, slice.layer);
+
+					readFramebuffer.Bind(GL_READ_FRAMEBUFFER);
+					writeFramebuffer.Bind(GL_DRAW_FRAMEBUFFER);
+
+					glBlitFramebuffer(0, 0, tex->width, tex->height,
+						slice.offset.x, slice.offset.y, 
+						slice.offset.x + slice.size.x, 
+						slice.offset.y + slice.size.y,
+						GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
 				}
 				else {
 
-					auto pixelCount = (size_t)tex->width * 
+					auto data = tex->GetData<uint8_t>();
+
+					std::vector<uint8_t> convertedData;
+
+					auto pixelCount = (size_t)tex->width *
 						(size_t)tex->height;
 					auto texChannels = tex->channels;
 
@@ -217,22 +271,24 @@ namespace Atlas {
 
 					}
 
+					if (!convertedData.size())
+						continue;
+
+					// Downscale the texture data if it hasn't the right size
+					if (slice.size.x != tex->width || slice.size.y != tex->height) {
+						Common::Image<uint8_t> image(tex->width, tex->height, tex->channels);
+						image.SetData(convertedData);
+						image.Resize(slice.size.x, slice.size.y);
+						convertedData = image.GetData();
+					}
+
+					texture.SetData(convertedData, slice.offset.x,
+						slice.offset.y, slice.layer, slice.size.x,
+						slice.size.y, 1);
+
 				}
 
-				if (!convertedData.size())
-					continue;
-
-				// Downscale the texture data if it hasn't the right size
-				if (slice.size.x != tex->width || slice.size.y != tex->height) {
-					Common::Image<uint8_t> image(tex->width, tex->height, tex->channels);
-					image.SetData(convertedData);
-					image.Resize(slice.size.x, slice.size.y);
-					convertedData = image.GetData();
-				}
-
-				texture.SetData(convertedData, slice.offset.x, 
-					slice.offset.y, slice.layer, slice.size.x, 
-					slice.size.y, 1);
+				slices[tex].push_back(slice);
 			}
 
 		}

--- a/src/texture/TextureAtlas.cpp
+++ b/src/texture/TextureAtlas.cpp
@@ -207,7 +207,7 @@ namespace Atlas {
 
 				}
 
-				layers++;				
+				layers++;
 
 			}
 

--- a/src/texture/TextureAtlas.h
+++ b/src/texture/TextureAtlas.h
@@ -54,11 +54,29 @@ namespace Atlas {
 			};
 
 			Texture2DArray texture;
-			std::map<Texture2D*, Slice> slices;
+			std::map<Texture2D*, std::vector<Slice>> slices;
 
 		private:
+			struct TextureStructure {
+				int32_t width;
+				int32_t height;
+				int32_t channels;
+				Texture2D* texture;
+			};
+
+			std::map<Texture2D*, TextureAtlas::Slice> CreateSlicesForAtlasLevel(std::vector<TextureStructure> textures, int32_t level);
+
+			void FillAtlas(std::map<Texture2D*, TextureAtlas::Slice> levelSlices);
+
 			int32_t padding = 1;
 			int32_t downscale = 1;
+
+			int32_t width = 0;
+			int32_t height = 0;
+			int32_t channels = 0;
+			int32_t layers = 0;
+
+			ivec2 offset;
 
 		};
 

--- a/src/texture/TextureAtlas.h
+++ b/src/texture/TextureAtlas.h
@@ -53,7 +53,7 @@ namespace Atlas {
 
 			};
 
-			Texture2DArray texture;
+			Texture2DArray textureArray;
 			std::map<Texture2D*, std::vector<Slice>> slices;
 
 		private:


### PR DESCRIPTION
- Mip maps are used for DDGI and RTR
- The atlas generator now keeps the data on the GPU while copying, thus improving performance
- Temporal passes now make use of group shared memory
- Atrous shader makes use of group shared memory
- Fixed a reprojection validation bug